### PR TITLE
fix: debug r key hooking once for every key pressed

### DIFF
--- a/lovely/hc_ads_ctrlr.toml
+++ b/lovely/hc_ads_ctrlr.toml
@@ -7,26 +7,17 @@ priority = 0
 [patches.pattern]
 target = "engine/controller.lua"
 pattern = '''
-local debugplus = require("debugplus.core")
-debugplus.handleKeys(self, key, dt)
+if self.hovering.target and self.hovering.target:is(Card) then
 '''
-position = "at"
+position = "before"
 payload = '''
-local debugplus = require("debugplus.core")
-local ref = debugplus.handleKeys
-debugplus.handleKeys = function(controller, key, dt)
-    local isAd = controller.hovering.target and controller.hovering.target.config and controller.hovering.target.config.ad
-    if controller.hovering.target and isAd then
-        local _card = controller.hovering.target
-        if key == "r" then
-           G.FUNCS.remove_ad(controller.hovering.target.config.id)
-        else
-            ref(controller, key, dt)
-        end
-    else
-        ref(controller, key, dt)
-    end
+do
+	local isAd = controller.hovering.target and controller.hovering.target.config and controller.hovering.target.config.ad
+	if isAd then
+		if key == "r" then
+		   G.FUNCS.remove_ad(controller.hovering.target.config.id)
+		end
+	end
 end
-debugplus.handleKeys(self, key, dt)
 '''
 match_indent = true


### PR DESCRIPTION
Completely untested phone code, beware.

Makes the r to remove ad keyind not hook DebugPlus every keypress and also works if DebugPlus is not installed (or I decided to change my patch) but debug mode is enabled.