### PR TITLE
Ensure Black Market reroll cost is set

### DIFF
--- a/Horsechicot/black_market.lua
+++ b/Horsechicot/black_market.lua
@@ -73,6 +73,7 @@ function Game:start_run(args)
   if saveTable and saveTable.cardAreas then
     G.GAME.market_table = saveTable.cardAreas.market_jokers
   end
+  G.GAME.current_round.market_reroll_cost = tonumber(G.GAME.current_round.market_reroll_cost) or 0
   G.GAME.cryptocurrency = G.GAME.cryptocurrency or 0.5
   return ret
 end


### PR DESCRIPTION
Prevent crash if Black Market is entered if the run starts with a Shop by ensuring its' either a saved number or 0 when (re)entering the run.