### PR TITLE
Fix field names in Jitem: CombatEventRewards and EncounterEventRewards

### DIFF
--- a/Jtem/events_definitions.lua
+++ b/Jtem/events_definitions.lua
@@ -4893,9 +4893,6 @@ local hpot_event_get_random_combat_reward = function(domain, seed)
 		{ sparkle = 35000, },
 		{ crypto = 0.5, },
 	}
-	for k, v in ipairs(G.localization.misc.CombatEvents.generic) do
-		if combat_rewards[k] then combat_rewards[k].text = v end
-	end
 
 	local encounter_rewards = {
 		{ jokers = { { rarity = "Uncommon" } }, },


### PR DESCRIPTION
Not sure if this is the intended fix but seems the most likely fix:

* Remove `CombatEventRewards` and `EncounterEventRewards` loop since nothing named similarly exists